### PR TITLE
optimize library to be used as dependency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml export-ignore
+/test/ export-ignore
+/scripts/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,7 @@
 /.gitignore export-ignore
 /.travis.yml export-ignore
 /phpunit.xml export-ignore
+/composer.json export-ignore
+/composer.lock export-ignore
 /test/ export-ignore
 /scripts/ export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Desktop.ini
 # keep some hiddens
 !.htaccess
 !/.gitignore
+!/.gitattributes
 !/.travis.yml
 
 /composer.lock

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,12 @@
     },
     "autoload": {
         "psr-0": {
-            "Props\\": ["src/", "test/"]
+            "Props\\": ["src/"]
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "Props\\": ["test/"]
         }
     }
 }


### PR DESCRIPTION
use autoload-dev to setup dev autoloader
this means the dev dependencies aren't setup when this library used as
dependency or composer install --no-dev is used
also exclude test files from git export (what composer --prefer-dist uses via github api to download .zip)
