### PR TITLE
Use psr/container directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "container-interop/container-interop": "^1.1",
+        "psr/container": "^1.0",
         "pimple/pimple": "~3.0"
     },
     "require-dev": {

--- a/src/Props/BadMethodCallException.php
+++ b/src/Props/BadMethodCallException.php
@@ -2,8 +2,8 @@
 
 namespace Props;
 
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerExceptionInterface;
 
-class BadMethodCallException extends \Exception implements ContainerException
+class BadMethodCallException extends \Exception implements ContainerExceptionInterface
 {
 }

--- a/src/Props/Container.php
+++ b/src/Props/Container.php
@@ -2,7 +2,7 @@
 
 namespace Props;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Container holding values which can be resolved upon reading and optionally stored and shared

--- a/src/Props/FactoryUncallableException.php
+++ b/src/Props/FactoryUncallableException.php
@@ -2,8 +2,8 @@
 
 namespace Props;
 
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerExceptionInterface;
 
-class FactoryUncallableException extends \Exception implements ContainerException
+class FactoryUncallableException extends \Exception implements ContainerExceptionInterface
 {
 }

--- a/src/Props/NotFoundException.php
+++ b/src/Props/NotFoundException.php
@@ -2,8 +2,9 @@
 
 namespace Props;
 
-use Interop\Container\Exception\NotFoundException as NotFound;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
-class NotFoundException extends \Exception implements NotFound
+class NotFoundException extends \Exception implements ContainerExceptionInterface, NotFoundExceptionInterface
 {
 }

--- a/src/Props/ValueUnresolvableException.php
+++ b/src/Props/ValueUnresolvableException.php
@@ -2,8 +2,8 @@
 
 namespace Props;
 
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerExceptionInterface;
 
-class ValueUnresolvableException extends \Exception implements ContainerException
+class ValueUnresolvableException extends \Exception implements ContainerExceptionInterface
 {
 }


### PR DESCRIPTION
container-interop/container-interop is abandoned, and just a shell for psr/container. This PR replaces all `Interop\Container` interface names with their `Psr\Container` counterparts.