### PR TITLE
update type hint to make compatible with interface

### DIFF
--- a/src/Props/Container.php
+++ b/src/Props/Container.php
@@ -102,7 +102,7 @@ class Container implements ContainerInterface
     /**
      * {@inheritdoc}
      */
-    public function has($name)
+    public function has($name): bool
     {
         return $this->__isset($name);
     }


### PR DESCRIPTION
This fixes a fatal error with Minify: 3.0.13 and php 8.1

```
Fatal error: Declaration of Props\Container::has($name) must be compatible with Psr\Container\ContainerInterface::has(string $id): bool in /var/www/html/vendor/mrclay/props-dic/src/Props/Container.php on line 105
```