### PR TITLE
Update Container.php

### DIFF
--- a/src/Props/Container.php
+++ b/src/Props/Container.php
@@ -102,7 +102,7 @@ class Container implements ContainerInterface
     /**
      * {@inheritdoc}
      */
-    public function has($name)
+    public function has(string $name): bool
     {
         return $this->__isset($name);
     }


### PR DESCRIPTION
Fixed the error that is giving in new versions of the props

Declaration of Props\Container::has($name) must be compatible with Psr\Container\ContainerInterface::has(string $id): bool in